### PR TITLE
fix(backend): Update Prisma schema path in Dockerfile and package.json

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -12,6 +12,9 @@ COPY . .
 # Installer les dépendances
 RUN npm install
 
+# Copier le fichier schema.prisma
+COPY ../../prisma ../../prisma
+
 # Générer le client Prisma
 RUN npx prisma generate
 

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -84,6 +84,6 @@
     "testEnvironment": "node"
   },
   "prisma": {
-    "schema": "./prisma/schema.prisma"
+    "schema": "../../prisma/schema.prisma"
   }
 }


### PR DESCRIPTION
This commit modifies the Dockerfile and package.json to correctly reference the Prisma schema file location. Key changes include:

- Updated the Dockerfile to copy the schema.prisma file from the correct relative path.
- Adjusted the schema path in package.json to ensure compatibility with the new file structure.

These changes aim to resolve issues related to Prisma client generation and ensure proper file accessibility during the build process.